### PR TITLE
Connected new message input and send button to endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -321,7 +321,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -638,6 +638,14 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
       "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+      "requires": {
+        "@types/node": "8.9.5"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.4.3",
@@ -10272,7 +10280,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@angular/router": "^6.1.6",
     "@ngxs/store": "^3.2.0",
     "@ngxs/websocket-plugin": "^3.2.0",
+    "@types/uuid": "^3.4.4",
     "cheerio": "^1.0.0-rc.2",
     "core-js": "^2.5.4",
     "express": "^4.16.3",

--- a/src/app/group-chats-module/actions/group-chats.actions.ts
+++ b/src/app/group-chats-module/actions/group-chats.actions.ts
@@ -35,3 +35,22 @@ export class FetchGroupChatFailed {
 	 */
 	constructor(public message: any) { }
 }
+
+/**
+ * Action alerting that a request to create a message succeeded
+ */
+export class CreateMessageSucceeded {
+	static readonly type = '[group chats state] create message succeeded';
+}
+
+/**
+ * Action alerting that a request to create a message failed
+ */
+export class CreateMessageFailed {
+	static readonly type = '[group chats state] create message failed';
+	/**
+	 * @constructor
+	 * @param message the failure message
+	 */
+	constructor(public message: any) { }
+}

--- a/src/app/group-chats-module/store/group-chats.state.ts
+++ b/src/app/group-chats-module/store/group-chats.state.ts
@@ -1,11 +1,14 @@
+import { v4 as uuid } from 'uuid';
 import { Action, StateContext, State } from "@ngxs/store";
 import * as GroupChatsStateActions from '../actions/group-chats.actions';
 import * as GroupChatsContainerActions from '../../cat-chat-module/group-chats/actions/group-chats-container.actions';
+import * as GroupMessagesContainerActions from '../../cat-chat-module/group-messages/actions/group-messages-container.actions';
 import { catchError, tap } from "rxjs/operators";
 import { asapScheduler, of, Observable } from "rxjs";
 import { GroupChatsHttpService } from "../services/group-chats.service";
 import { FetchGroupsRequest } from "../services/models/groups/fetch-groups.request";
 import { FetchMessagesRequest } from "../services/models/messages/fetch-messages.request";
+import { CreateMessageRequest } from "../services/models/messages/create-message.request";
 
 export interface GroupChatsStateModel {
     groupChats: any[];
@@ -13,11 +16,13 @@ export interface GroupChatsStateModel {
         id: string;
         messages: any;
     }
+    newMessage: any;
 }
 
 const defaults: GroupChatsStateModel = {
     groupChats: [],
-    selectedGroupChat: null
+    selectedGroupChat: null,
+    newMessage: null
 }
 
 @State<GroupChatsStateModel>({
@@ -28,9 +33,10 @@ const defaults: GroupChatsStateModel = {
 export class GroupChatsState {
     constructor(private groupChatsService: GroupChatsHttpService) { }
 
-    @Action(GroupChatsContainerActions.Initialized)
+    @Action([GroupChatsContainerActions.Initialized, GroupChatsStateActions.CreateMessageSucceeded])
     fetchGroups({ patchState, dispatch }: StateContext<GroupChatsStateModel>) {
         const request = new FetchGroupsRequest();
+
         return this.groupChatsService.fetchGroups(request).pipe(
             tap(groupChats => {
                 patchState({
@@ -48,6 +54,7 @@ export class GroupChatsState {
     fetchGroup({ patchState, dispatch }: StateContext<GroupChatsStateModel>, { groupChat }: GroupChatsContainerActions.GroupChatSelected) {
         const request: FetchMessagesRequest = new FetchMessagesRequest();
         request.group_id = groupChat.group_id;
+
         return this.groupChatsService.fetchMessages(request).pipe(
             tap(messages => {
                 patchState({
@@ -60,6 +67,52 @@ export class GroupChatsState {
             }),
             catchError(error => {
                 return of(asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatFailed(error))));
+            })
+        );
+    }
+
+    @Action(GroupChatsStateActions.CreateMessageSucceeded)
+    refreshMessages({ patchState, getState, dispatch }: StateContext<GroupChatsStateModel>) {
+        const selectedChat = getState().selectedGroupChat;
+        const request: FetchMessagesRequest = new FetchMessagesRequest();
+        request.group_id = selectedChat.id;
+
+
+        return this.groupChatsService.fetchMessages(request).pipe(
+            tap(messages => {
+                patchState({
+                    selectedGroupChat: { 
+                        ...selectedChat,
+                        messages: messages
+                    }
+                });
+                asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatSucceeded()));
+            }),
+            catchError(error => {
+                return of(asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatFailed(error))));
+            })
+        );
+    }
+
+    @Action(GroupMessagesContainerActions.SendMessage)
+    sendMessage({ getState, dispatch }: StateContext<GroupChatsStateModel>, { content }: GroupMessagesContainerActions.SendMessage) {
+        const state = getState();
+        const body = {
+            message: {
+                text: content.text,
+                source_guid: uuid()
+            }
+        };
+        const request: CreateMessageRequest = new CreateMessageRequest();
+        request.group_id = state.selectedGroupChat.id;
+        request.body = body;
+
+        return this.groupChatsService.createMessage(request).pipe(
+            tap(_ => {
+                asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.CreateMessageSucceeded()));
+            }),
+            catchError(error => {
+                return of(asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.CreateMessageFailed(error))));
             })
         );
     }


### PR DESCRIPTION
**_I'd wait to review this pull request until you feel comfortable with how the ui components work. [NGXS](https://ngxs.gitbook.io/ngxs/getting-started) is also a prerequisite. This deals with how the application state (global storage) responds to actions emitted by the component_**

This PR closed issue #5.

- Created action handler that responds to a `SendMessage` action emitted by `GroupMessageContainer`. Sends HTTP POST message containing new message to GroupMe's endpoint using the `GroupChatsHttpService`
- Created `CreateMessageSucceeded` and `CreateMessageFailed` actions which are emitted by `group-chats.state.ts` based on the result of the HTTP POST message. 
  - The `CreateMessageSucceeded` action is added to the `fetchGroups` action handler of `GroupChatsState`. This results in `GroupChatsState` fetching the user's group chats (aka refreshing) from GroupMe's api anytime a new message is successfully sent. 
  - Nothing is handling the `CreateMessageFailed` action at the moment, but it's emitted out of good practice. In the future if we want to display a message to the user that the message failed to send, it'll be easy to implement. Plus by emitting all actions, we can track the flow of calls and responses throughout the application using the [Chrome redux devtools extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)

The ultimate result of these changes is that now, the `SendMessage` action (emitted by the ui layer) is received by `GroupChatsState` and the application contacts the backend to update the application state as necessary.