### PR TITLE
Chat specific new message queues

### DIFF
--- a/src/app/group-chats-module/actions/group-chats.actions.ts
+++ b/src/app/group-chats-module/actions/group-chats.actions.ts
@@ -22,6 +22,11 @@ export class FetchGroupChatsFailed {
  */
 export class FetchGroupChatSucceeded {
     static readonly type = '[group chats state] fetch group chat succeeded';
+    /**
+	 * @constructor
+	 * @param chatId the ID of the fetched chat
+	 */
+    constructor(public chatId: any) { }
 }
 
 /**

--- a/src/app/group-chats-module/store/group-chats.selectors.ts
+++ b/src/app/group-chats-module/store/group-chats.selectors.ts
@@ -24,6 +24,15 @@ export class GroupChatsSelectors {
     }
 
     /**
+     * Returns the currently selected group chat's ID
+     * @param state @see GroupChatsStateModel
+     */
+    @Selector([GroupChatsState])
+    static getSelectedChatId(state: GroupChatsStateModel) {
+        return state.selectedGroupChat.chat.id;
+    }
+
+    /**
 	 * Returns the currently selected group chat's messages
 	 * @param state @see GroupChatsStateModel
 	 */

--- a/src/app/group-chats-module/store/group-chats.state.ts
+++ b/src/app/group-chats-module/store/group-chats.state.ts
@@ -73,7 +73,7 @@ export class GroupChatsState {
                         messages: [messages]
                     }
                 });
-                asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatSucceeded()));
+                asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatSucceeded(groupChat.group_id)));
             }),
             catchError(error => {
                 return of(asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatFailed(error))));

--- a/src/app/group-chats-module/store/group-chats.state.ts
+++ b/src/app/group-chats-module/store/group-chats.state.ts
@@ -125,7 +125,7 @@ export class GroupChatsState {
                         messages: [messages]
                     }
                 });
-                asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatSucceeded()));
+                asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatSucceeded(selectedChat.chat.id)));
             }),
             catchError(error => {
                 return of(asapScheduler.schedule(() => dispatch(new GroupChatsStateActions.FetchGroupChatFailed(error))));

--- a/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.html
+++ b/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.html
@@ -10,5 +10,8 @@
 				{{groupChat.messages.preview.nickname}}: {{trimMessage(groupChat.messages.preview.text)}}
 			</div>
 		</div>
+		<div *ngIf="newMessageCount(groupChat.id) > 0" class="new-message-counter">
+			{{newMessageCount(groupChat.id)}}
+		</div>
 	</div>
 </div>

--- a/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.html
+++ b/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.html
@@ -10,8 +10,8 @@
 				{{groupChat.messages.preview.nickname}}: {{trimMessage(groupChat.messages.preview.text)}}
 			</div>
 		</div>
-		<div *ngIf="newMessageCount(groupChat.id) > 0" class="new-message-counter">
-			{{newMessageCount(groupChat.id)}}
+		<div *ngIf="getNewMessageCount(groupChat.id) > 0" class="new-message-counter">
+			{{getNewMessageCount(groupChat.id)}}
 		</div>
 	</div>
 </div>

--- a/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.less
+++ b/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.less
@@ -40,6 +40,18 @@
             }
         }
 
+        .new-message-counter {
+            align-self: flex-end;
+            font-size: 1em;
+            font-weight: 600;
+            height: 24px;
+            width: 24px;
+            border-radius: 50%;
+            background: radial-gradient(circle, #E83232 0%, #CA3636 100%);
+            box-shadow: 0 2px 2px 0 rgba(240,172,55,0.5);
+            text-align: center;
+        }
+
         &.selected {
             background: linear-gradient(135deg, #D4A61B 0%, #F0AC37 100%);
             border-radius: 4px;

--- a/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.ts
+++ b/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.ts
@@ -9,6 +9,7 @@ export class GroupChatsListComponent implements AfterViewInit {
     @ViewChild('scrollView') private scrollView: ElementRef;
     @Input() groupChatsList: any[];
     @Input() selectedGroupChat: any;
+    @Input() messageQueues: any[];
 
     @Output() groupChatSelected: EventEmitter<string> = new EventEmitter<string>();
 
@@ -19,6 +20,13 @@ export class GroupChatsListComponent implements AfterViewInit {
     trimMessage(message: string): string {
         const maxLength = 100;
         return message.length > maxLength ? message.substring(0, maxLength).trim() + '...' : message;
+    }
+
+    newMessageCount(chatId: string): number {
+        const messageQueue = this.messageQueues.find(queue => queue.chatId === chatId);
+        console.log('message sizes', this.messageQueues);
+        console.log('message queue', messageQueue);
+        return messageQueue ? messageQueue.queue.length : 0;
     }
 
     private initializeScroll(): void {

--- a/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.ts
+++ b/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.ts
@@ -16,6 +16,11 @@ export class GroupChatsListComponent implements AfterViewInit {
         this.initializeScroll();
     }
 
+    trimMessage(message: string): string {
+        const maxLength = 100;
+        return message.length > maxLength ? message.substring(0, maxLength).trim() + '...' : message;
+    }
+
     private initializeScroll(): void {
         this.scrollView.nativeElement.addEventListener('scroll', () => {
             const nativeElement = this.scrollView.nativeElement;
@@ -24,13 +29,5 @@ export class GroupChatsListComponent implements AfterViewInit {
                 // this.scrolledToTop.emit();
             }
         });
-    }
-
-    public trimMessage(message: string): string {
-        if (message.length > 50) {
-            return message.substring(0,49).trim() + '...';
-        } else {
-            return message
-        }
     }
 }

--- a/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.ts
+++ b/src/app/ui-module/group-chats/components/group-chats-list/group-chats-list.component.ts
@@ -22,10 +22,8 @@ export class GroupChatsListComponent implements AfterViewInit {
         return message.length > maxLength ? message.substring(0, maxLength).trim() + '...' : message;
     }
 
-    newMessageCount(chatId: string): number {
+    getNewMessageCount(chatId: string): number {
         const messageQueue = this.messageQueues.find(queue => queue.chatId === chatId);
-        console.log('message sizes', this.messageQueues);
-        console.log('message queue', messageQueue);
         return messageQueue ? messageQueue.queue.length : 0;
     }
 

--- a/src/app/ui-module/group-chats/container/group-chats.container.html
+++ b/src/app/ui-module/group-chats/container/group-chats.container.html
@@ -1,2 +1,2 @@
-<group-chats-list-component [groupChatsList]="groupChats$ | async" [selectedGroupChat]="selectedGroupChat$ | async" (groupChatSelected)="groupChatSelected($event)">
+<group-chats-list-component [groupChatsList]="groupChats$ | async" [selectedGroupChat]="selectedGroupChat$ | async" [messageQueues]="messageQueues$ | async" (groupChatSelected)="groupChatSelected($event)">
 </group-chats-list-component>

--- a/src/app/ui-module/group-chats/container/group-chats.container.ts
+++ b/src/app/ui-module/group-chats/container/group-chats.container.ts
@@ -3,6 +3,7 @@ import { Store, Select } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import * as Actions from '../actions/group-chats-container.actions';
 import { GroupChatsSelectors } from '../../../group-chats-module/store/group-chats.selectors';
+import { WebSocketSelectors } from '../../../web-socket-module/store/web-socket.selectors';
 
 @Component({
     selector: 'group-chats-container',
@@ -11,6 +12,7 @@ import { GroupChatsSelectors } from '../../../group-chats-module/store/group-cha
 export class GroupChatsContainer implements OnInit {
     @Select(GroupChatsSelectors.getGroupChats) groupChats$: Observable<any>;
     @Select(GroupChatsSelectors.getSelectedChatDetails) selectedGroupChat$: Observable<any>;
+    @Select(WebSocketSelectors.getMessageQueues) messageQueues$: Observable<any[]>;
 
     constructor(private store: Store) { }
 

--- a/src/app/web-socket-module/store/models/message-queue.ts
+++ b/src/app/web-socket-module/store/models/message-queue.ts
@@ -1,0 +1,4 @@
+export class MessageQueue {
+    chatId: string;
+    queue: any[];
+}

--- a/src/app/web-socket-module/store/web-socket.selectors.ts
+++ b/src/app/web-socket-module/store/web-socket.selectors.ts
@@ -5,11 +5,16 @@ import { WebSocketState, WebSocketStateModel } from './web-socket.state';
  * Selector class for @see WebSocketState
  */
 export class WebSocketSelectors {
+    /**
+     * Returns the new message queue for the specified chat id
+     * @param state @see WebSocketStateModel
+     */
     static getMessageQueue(chatId: string) {
         return createSelector([WebSocketState], (state: WebSocketStateModel) => {
             return state.messageQueues.find(messageQueue => messageQueue.chatId === chatId);
         });
     }
+
     /**
      * Returns all new message queues
      * @param state @see WebSocketStateModel

--- a/src/app/web-socket-module/store/web-socket.selectors.ts
+++ b/src/app/web-socket-module/store/web-socket.selectors.ts
@@ -1,8 +1,21 @@
-import { Selector } from '@ngxs/store';
+import { Selector, createSelector } from '@ngxs/store';
 import { WebSocketState, WebSocketStateModel } from './web-socket.state';
 
 /**
  * Selector class for @see WebSocketState
  */
 export class WebSocketSelectors {
+    static getMessageQueue(chatId: string) {
+        return createSelector([WebSocketState], (state: WebSocketStateModel) => {
+            return state.messageQueues.find(messageQueue => messageQueue.chatId === chatId);
+        });
+    }
+    /**
+     * Returns all new message queues
+     * @param state @see WebSocketStateModel
+     */
+    @Selector([WebSocketState])
+    static getMessageQueues(state: WebSocketStateModel) {
+        return state.messageQueues;
+    }
 }

--- a/src/app/web-socket-module/store/web-socket.state.ts
+++ b/src/app/web-socket-module/store/web-socket.state.ts
@@ -1,6 +1,7 @@
 import { Action, StateContext, State, Store } from '@ngxs/store';
 import * as WebSocketServiceActions from '../actions/web-socket.actions';
 import * as GroupChatsContainerActions from '../../ui-module/group-chats/actions/group-chats-container.actions';
+import * as GroupChatsStateActions from '../../group-chats-module/actions/group-chats.actions';
 import { GroupChatsSelectors } from '../../group-chats-module/store/group-chats.selectors';
 import { MessageQueue } from './models/message-queue';
 import { UserSelectors } from '../../user-module/store/user.selectors';
@@ -41,9 +42,9 @@ export class WebSocketState {
     messageReceived({ getState, patchState }: StateContext<WebSocketStateModel>, action: WebSocketServiceActions.MessageReceived) {
         const userId = this.store.selectSnapshot(UserSelectors.getUserId);
         // Ignore all messages from this user
-        if (userId === action.message.user_id) {
-            return;
-        }
+        // if (userId === action.message.user_id) {
+        //     return;
+        // }
 
         const selectedChatId = this.store.selectSnapshot(GroupChatsSelectors.getSelectedChatId);
         const messageChatId = action.message.group_id || action.message.chat_id;
@@ -68,10 +69,10 @@ export class WebSocketState {
         }
     }
 
-    @Action(GroupChatsContainerActions.GroupChatSelected)
-    clearMessageQueue({ getState, patchState }: StateContext<WebSocketStateModel>, action: GroupChatsContainerActions.GroupChatSelected) {
+    @Action(GroupChatsStateActions.FetchGroupChatSucceeded)
+    clearMessageQueue({ getState, patchState }: StateContext<WebSocketStateModel>, action: GroupChatsStateActions.FetchGroupChatSucceeded) {
         const messageQueues = getState().messageQueues;
-        const selectedQueueIndex = messageQueues.findIndex(queue => queue.chatId === action.groupChat.group_id);
+        const selectedQueueIndex = messageQueues.findIndex(queue => queue.chatId === action.chatId);
         if (selectedQueueIndex >= 0) {
             messageQueues.splice(selectedQueueIndex, 1);
             patchState({

--- a/src/app/web-socket-module/store/web-socket.state.ts
+++ b/src/app/web-socket-module/store/web-socket.state.ts
@@ -1,6 +1,5 @@
 import { Action, StateContext, State, Store } from '@ngxs/store';
 import * as WebSocketServiceActions from '../actions/web-socket.actions';
-import * as GroupChatsContainerActions from '../../ui-module/group-chats/actions/group-chats-container.actions';
 import * as GroupChatsStateActions from '../../group-chats-module/actions/group-chats.actions';
 import { GroupChatsSelectors } from '../../group-chats-module/store/group-chats.selectors';
 import { MessageQueue } from './models/message-queue';
@@ -42,9 +41,9 @@ export class WebSocketState {
     messageReceived({ getState, patchState }: StateContext<WebSocketStateModel>, action: WebSocketServiceActions.MessageReceived) {
         const userId = this.store.selectSnapshot(UserSelectors.getUserId);
         // Ignore all messages from this user
-        // if (userId === action.message.user_id) {
-        //     return;
-        // }
+        if (userId === action.message.user_id) {
+            return;
+        }
 
         const selectedChatId = this.store.selectSnapshot(GroupChatsSelectors.getSelectedChatId);
         const messageChatId = action.message.group_id || action.message.chat_id;

--- a/tslint.json
+++ b/tslint.json
@@ -28,7 +28,7 @@
     "interface-over-type-literal": true,
     "label-position": true,
     "max-line-length": [
-      true,
+      false,
       140
     ],
     "member-access": false,


### PR DESCRIPTION
Closes #32 

Most of our communication with GroupMe happens over HTTP requests. For those to work however, we have to actively request some resources from them. This pattern doesn't work very well for receiving incoming messages, as we would constantly have to check in to see if any new messages have arrived. 

Conveniently, GroupMe offers up a websocket endpoint for receiving new message events. A websocket offers a persistent connection, the connection is kept open until one of the parties disconnects. This is in contrast to HTTP requests, which are asynchronus; the connection is closed between sending a request and receiving a response. 

This websocket is what the web-socket-module is set up to connect to. The web-socket-module connects to GroupMe's websocket endpoint, receives incoming messages, and stores them in NGXS. 

This PR converts the WebSocketStateModel to have separate new message queues for each chat. This allows us to just delete a message queue when a user clicks on that chat (they've read all the new messages). We can also use selectors to count the number of unread messages for each chat, and display an icon indicating there are new messages.

<img width="1454" alt="capture" src="https://user-images.githubusercontent.com/26495271/46266557-c61a4c80-c4e4-11e8-8e6e-fdd943f4129f.PNG">
