### PR TITLE
Message list scrolling

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -80,6 +80,7 @@
               "browserTarget": "cat-chat:build:production"
             },
             "ci": {
+              "browserTarget": "cat-chat:build:production",
               "progress": false
             }
           }

--- a/angular.json
+++ b/angular.json
@@ -35,6 +35,8 @@
                   "with": "src/environments/environment.dev.ts"
                 }
               ],
+              "progress": true,
+              "verbose": true,
               "optimization": false,
               "outputHashing": "all",
               "sourceMap": true,
@@ -43,6 +45,7 @@
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
+              "watch": true,
               "buildOptimizer": true
             },
             "production": {
@@ -67,7 +70,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "cat-chat:build"
+            "browserTarget": "cat-chat:build:dev"
           },
           "configurations": {
             "dev": {

--- a/src/app/selected-chats-module/actions/selected-chats.actions.ts
+++ b/src/app/selected-chats-module/actions/selected-chats.actions.ts
@@ -102,6 +102,30 @@ export class LoadMoreMessagesFailed {
 }
 
 /**
+ * Action alerting that a request to fetch newer messages succeeded
+ */
+export class FetchNewerMessagesSucceeded {
+    static readonly type = '[group chats state] fetch newer messages succeeded';
+    /**
+	 * @constructor
+	 * @param chatId the chat ID
+	 */
+    constructor(public chatId: any) { }
+}
+
+/**
+ * Action alerting that a request to fetch newer messages failed
+ */
+export class FetchNewerMessagesFailed {
+    static readonly type = '[group chats state] fetch newer messages failed';
+    /**
+	 * @constructor
+	 * @param message the failure message
+	 */
+    constructor(public message: any) { }
+}
+
+/**
  * Action alerting that a request to like a message succeeded
  */
 export class LikeMessageSucceeded {

--- a/src/app/ui-module/group-messages/components/group-messages-list/group-messages-list.component.html
+++ b/src/app/ui-module/group-messages/components/group-messages-list/group-messages-list.component.html
@@ -1,3 +1,11 @@
 <div *ngFor="let page of messagePageList; let i = index" id="chat-{{chatId}}-page-{{i}}">
     <group-messages-list-item-container *ngFor="let message of page; let j = index" id="chat-{{chatId}}-page-{{i}}-message-{{j}}" [chatId]="chatId" [message]="message"></group-messages-list-item-container> 
 </div>
+
+<div class="full-width-container">
+    <div class="scroll-to-bottom-container">
+        <button *ngIf="!scrolledToBottom" type="button" (click)="scrollToBottom()" class="scroll-to-bottom" [ngClass]="{'new-messages': newMessages}">
+            <span class="glyphicon glyphicon-arrow-down"></span>
+        </button>
+    </div>
+</div>

--- a/src/app/ui-module/group-messages/components/group-messages-list/group-messages-list.component.less
+++ b/src/app/ui-module/group-messages/components/group-messages-list/group-messages-list.component.less
@@ -2,3 +2,30 @@
     flex-basis: 100%;
     overflow-y: auto;
 }
+
+.full-width-container {
+    display: flex;
+    justify-content: flex-end;
+    max-width: 100%;
+
+    .scroll-to-bottom-container {
+        position: absolute;
+        bottom: 100px;
+
+        .scroll-to-bottom {
+            color: black;
+            z-index: 3;
+            position: relative;
+            right: 15px;  
+            width: 50px;
+            height: 50px;
+            border: 0px;
+            border-radius: 50%;
+            background-color: lightslategray;
+
+            &.new-messages {
+                background-color: #F0AC37;
+            }
+        }
+    }
+}

--- a/src/app/ui-module/group-messages/components/message-text/message-text.component.less
+++ b/src/app/ui-module/group-messages/components/message-text/message-text.component.less
@@ -4,3 +4,7 @@
     font-weight: 700;
     color: #F0AC37;
 }
+
+/deep/ .message-text-hyperlink {
+    word-break: break-word;
+}

--- a/src/app/web-socket-module/store/web-socket.state.ts
+++ b/src/app/web-socket-module/store/web-socket.state.ts
@@ -1,13 +1,10 @@
 import { Action, StateContext, State, Store } from '@ngxs/store';
 import * as WebSocketServiceActions from '../actions/web-socket.actions';
-import * as GroupChatsStateActions from '../../group-chats-module/actions/group-chats.actions';
 import * as SelectedChatsStateActions from '../../selected-chats-module/actions/selected-chats.actions';
-import { GroupChatsSelectors } from '../../group-chats-module/store/group-chats.selectors';
 import { MessageQueue } from './models/message-queue';
 import { UserSelectors } from '../../user-module/store/user.selectors';
 import { SelectedChatsSelectors } from '../../selected-chats-module/store/selected-chats.selectors';
-import { environment } from 'src/environments/environment';
-import { asapScheduler, of, Observable, throwError } from 'rxjs';
+import { asapScheduler } from 'rxjs';
 
 export interface WebSocketStateModel {
     isOpen: boolean;
@@ -44,10 +41,7 @@ export class WebSocketState {
     @Action(WebSocketServiceActions.MessageReceived)
     messageReceived({ getState, patchState, dispatch }: StateContext<WebSocketStateModel>, action: WebSocketServiceActions.MessageReceived) {
         const userId = this.store.selectSnapshot(UserSelectors.getUserId);
-        // Ignore all messages from this user; Messages sent by this user are still received over the websocket, this prevents those
-        //  messages from being registered
-        // Disabled in dev environment; Allows simulation of incoming messages by sending messages from another device
-        if (environment.production && userId === action.message.user_id) {
+        if (userId === action.message.user_id) {
             return;
         }
 


### PR DESCRIPTION
Closes #75 

If you find any bugs with the scrolling once you add this code to your branch let me know. We can refine this scrolling functionality over time. 

I've disabled the functionality where we refresh the message list whenever we like or dislike a message. It interferes with how scrolling works now, since we no longer refetch all of the messages every time we successfully send/like/unlike a message. It will need to get updated once we figure out how to detect that someone else has liked a message. 

I've also added a small build configuration that will be a little nice for us. Now instead of typing "ng serve --watch --configuration=dev" every time you want to run the program locally, you just need to say "ng serve". It will know to use the dev configuration with the watch flag.